### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ addons:
       - aspell
       - aspell-en
 language: perl
+
+arch:
+ - amd64
+ - ppc64le
+ 
 perl:
   - blead       # builds perl from git
   - dev         # latest point release
@@ -18,6 +23,20 @@ perl:
   - "5.12"
   - "5.10"
   - "5.8"
+  
+  
+  
+#jobs excuded from the ppc64le arch
+jobs:
+ exclude:
+   - arch: ppc64le
+     perl: dev
+   - arch: ppc64le
+     perl: 5.12
+   - arch: ppc64le
+     perl: 5.10
+   - arch: ppc64le
+     perl: 5.8
 env:
   global:
     - AUTHOR_TESTING=1


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and jobs excluded from the ppc64le arch because it supports higher version, so i have updated the version and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/MooseX-UndefTolerant/builds/202496089

Please have a look.

Regards,
Manish Kumar